### PR TITLE
reexport VectorCore + VectorAcelerate

### DIFF
--- a/Sources/EmbedKit/Acceleration/AccelerateBLAS.swift
+++ b/Sources/EmbedKit/Acceleration/AccelerateBLAS.swift
@@ -4,6 +4,7 @@
 import Foundation
 import Accelerate
 import VectorCore
+import struct VectorCore.TopKResult
 
 /// High-performance CPU operations using Apple's Accelerate framework.
 ///

--- a/Sources/EmbedKit/Exports.swift
+++ b/Sources/EmbedKit/Exports.swift
@@ -1,0 +1,5 @@
+// EmbedKit - Module Re-exports
+// Re-exports VSK dependencies for consumer convenience
+
+@_exported import VectorCore
+@_exported import VectorAccelerate


### PR DESCRIPTION
reexporting core dependancies so consumers don't need to manage multiple deps