### PR TITLE
Bump for critical bug fixes in VectorAccelerate

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "e0b08c8b7c09c7887cb3beef5fecabbe75d7a8492e627bec0ca754ff267ec465",
+  "originHash" : "dc489a4983e7ee5714f15268b30bbf8791a0ce4258dd40c10075b2f5177def05",
   "pins" : [
     {
       "identity" : "onnxruntime-swift-package-manager",
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/gifton/VectorAccelerate.git",
       "state" : {
-        "revision" : "4b5ee9262d749c9c6d325daad86ad8374dc67df7",
-        "version" : "0.3.1"
+        "revision" : "620bfb17ac2e95c456ed6a3ac355271726e21980",
+        "version" : "0.3.2"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -46,7 +46,7 @@ let package = Package(
     dependencies: [
         // VSK dependencies - VectorAccelerate provides GPU-first indexing (v0.3.0+)
         .package(url: "https://github.com/gifton/VectorCore.git", from: "0.1.6"),
-        .package(url: "https://github.com/gifton/VectorAccelerate.git", from: "0.3.1"),
+        .package(url: "https://github.com/gifton/VectorAccelerate.git", from: "0.3.2"),
 
         // System dependencies
         .package(url: "https://github.com/apple/swift-log.git", from: "1.5.0"),


### PR DESCRIPTION
no source changes, VA has major fixes to IVF (vs flat) and our source relies heavily on this similarity search with significantly higher recall, and can use higher nprobe values (n > 8, defaulted to n = 16 currently)