### PR TITLE
fix compaction w/ VA 0.3.2

### DIFF
--- a/Sources/EmbedKit/Storage/EmbeddingStore.swift
+++ b/Sources/EmbedKit/Storage/EmbeddingStore.swift
@@ -385,24 +385,11 @@ public actor EmbeddingStore: EmbeddingStorable {
 
     /// Compact the index to reclaim space from deleted vectors.
     ///
-    /// Compaction may remap VectorHandles. This method updates all internal
-    /// mappings to use the new handles.
-    ///
-    /// Returns the number of handles that were remapped.
-    @discardableResult
-    public func compact() async throws -> Int {
-        let remapping = try await index.compact()
-
-        // Update handle mappings with new handles
-        for (oldHandle, newHandle) in remapping {
-            if let id = handleToID[oldHandle] {
-                handleToID.removeValue(forKey: oldHandle)
-                handleToID[newHandle] = id
-                idToHandle[id] = newHandle
-            }
-        }
-
-        return remapping.count
+    /// With VectorAccelerate 0.3.2+ stable handles, `VectorHandle` values remain
+    /// valid across compaction. No handle remapping is needed - the underlying
+    /// index maintains an internal indirection table.
+    public func compact() async throws {
+        try await index.compact()
     }
 
     // MARK: - Statistics

--- a/Tests/EmbedKitTests/EmbeddingStoreIndexTypeTests.swift
+++ b/Tests/EmbedKitTests/EmbeddingStoreIndexTypeTests.swift
@@ -261,11 +261,8 @@ struct EmbeddingStoreCompactionTests {
         let countBefore = await store.count
         #expect(countBefore == 10)
 
-        // Compact
-        let remapped = try await store.compact()
-
-        // Some handles may have been remapped
-        #expect(remapped >= 0)
+        // Compact (stable handles - no remapping needed)
+        try await store.compact()
 
         // Count should still be correct
         let countAfter = await store.count


### PR DESCRIPTION
VectorAccelerates new compaction method does not require mapping between new and old handles - stableID's are used and preserved through compaction 
