### PR TITLE
bump dep for VectorCore and minor usage improvement in EmbeddingSrore

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "4a39d4a87adc3c5bdae15a04efbe2c366ba1e144d0f9d5c4dbb95672685acbe8",
+  "originHash" : "2f6f09d6f30e7c50dd4a955385afdb2ac29aef6ddd32d1d44c90425ce16ecfea",
   "pins" : [
     {
       "identity" : "metalcompilerplugin",
@@ -33,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/gifton/VectorAccelerate.git",
       "state" : {
-        "revision" : "a14cab4ac45ea13e22cf9b55c4dcae9d59cf8d28",
-        "version" : "0.3.6"
+        "revision" : "e3a3b93507cfdd5d98aa81aed413ee643f31b99d",
+        "version" : "0.4.1"
       }
     },
     {
@@ -42,8 +42,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/gifton/VectorCore.git",
       "state" : {
-        "revision" : "506d3d2adc893fe1d24513b329568a6b834f20bc",
-        "version" : "0.1.6"
+        "revision" : "bd6e3ffa61281d56960557f051a5fe746ea6a9e5",
+        "version" : "0.2.0"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -45,8 +45,8 @@ let package = Package(
     ],
     dependencies: [
         // VSK dependencies - VectorAccelerate provides GPU-first vector indexing
-        .package(url: "https://github.com/gifton/VectorCore.git", from: "0.1.6"),
-        .package(url: "https://github.com/gifton/VectorAccelerate.git", from: "0.3.6"),
+        .package(url: "https://github.com/gifton/VectorCore.git", from: "0.2.0"),
+        .package(url: "https://github.com/gifton/VectorAccelerate.git", from: "0.4.1"),
 
         // System dependencies
         .package(url: "https://github.com/apple/swift-log.git", from: "1.5.0"),

--- a/Sources/EmbedKit/Storage/EmbeddingStore.swift
+++ b/Sources/EmbedKit/Storage/EmbeddingStore.swift
@@ -198,10 +198,10 @@ public actor EmbeddingStore: EmbeddingStorable {
             )
         }
 
-        let results: [IndexSearchResult]
+        let searchResults: SearchResults<VectorHandle>
         if let filter = filter {
             // Use filtered search with predicate
-            results = try await index.search(query: query.vector, k: k) { [metadataStore, handleToID] handle, vaMetadata in
+            searchResults = try await index.search(query: query.vector, k: k) { [metadataStore, handleToID] handle, vaMetadata in
                 // Get our string ID for this handle
                 guard let id = handleToID[handle] else { return true }
                 // Get metadata from our store (more complete than VA metadata)
@@ -209,11 +209,11 @@ public actor EmbeddingStore: EmbeddingStorable {
                 return filter(metadata)
             }
         } else {
-            results = try await index.search(query: query.vector, k: k)
+            searchResults = try await index.search(query: query.vector, k: k)
         }
 
-        return results.compactMap { result in
-            guard let id = handleToID[result.handle] else { return nil }
+        return searchResults.compactMap { result in
+            guard let id = handleToID[result.id] else { return nil }
             return EmbeddingSearchResult(
                 id: id,
                 distance: result.distance,


### PR DESCRIPTION
Our dependancies VectorCore and VectorAcceelerate had major improvements made to their performance and resilience. this PR is to conform to the new versions (0.42.0 and 0.4.0 respectively) 
Only minor change to the EmbeddingStore to utilize the new `SearchResults<VectorHandle>` object from the previous `[IndexSearchResult]`