### PR TITLE
feat: VSK Upgrade Gaps & VectorAccelerate 0.4.3

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -33,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/gifton/VectorAccelerate.git",
       "state" : {
-        "revision" : "e3a3b93507cfdd5d98aa81aed413ee643f31b99d",
-        "version" : "0.4.1"
+        "revision" : "ccb80e0abea884a6ae59ebb86fdc6132a010f778",
+        "version" : "0.4.3"
       }
     },
     {

--- a/Sources/EmbedKit/Acceleration/AccelerationManager.swift
+++ b/Sources/EmbedKit/Acceleration/AccelerationManager.swift
@@ -138,7 +138,7 @@ public actor AccelerationManager {
 
     /// GPU decision engine for adaptive GPU/CPU routing.
     /// Nil when using `.alwaysGPU` or `.alwaysCPU` profiles.
-    private let decisionEngine: GPUDecisionEngine?
+    public let decisionEngine: GPUDecisionEngine?
 
     /// Current decision profile for GPU/CPU routing.
     private var decisionProfile: GPUDecisionProfile

--- a/Sources/EmbedKit/Caching/CacheTypes.swift
+++ b/Sources/EmbedKit/Caching/CacheTypes.swift
@@ -5,6 +5,21 @@ import Foundation
 
 // MARK: - Cache Configuration
 
+/// Write-Ahead Logging mode for SQLite database connection.
+public enum CacheWALMode: Sendable {
+    case disabled
+    case durable
+    case balanced
+    case performant
+}
+
+/// Storage format for embedding vectors.
+public enum EmbeddingStorageFormat: Sendable {
+    case float32
+    case int8
+    case binary
+}
+
 /// Configuration for persistent embedding cache.
 public struct CacheConfiguration: Sendable {
     /// Maximum number of embeddings to store (0 = unlimited).
@@ -28,7 +43,17 @@ public struct CacheConfiguration: Sendable {
     public var ttlSeconds: TimeInterval
 
     /// Enable write-ahead logging for better crash recovery.
-    public var enableWAL: Bool
+    @available(*, deprecated, message: "Use walMode instead")
+    public var enableWAL: Bool {
+        get { walMode != .disabled }
+        set { walMode = newValue ? .durable : .disabled }
+    }
+
+    /// Write-Ahead Logging mode for better crash recovery and performance tradeoffs.
+    public var walMode: CacheWALMode
+
+    /// Storage format for embedding vectors.
+    public var storageFormat: EmbeddingStorageFormat
 
     /// Default configuration with reasonable limits.
     public static let `default` = CacheConfiguration(
@@ -38,7 +63,8 @@ public struct CacheConfiguration: Sendable {
         deduplicationThreshold: 0.98,
         autoEvict: true,
         ttlSeconds: 0,
-        enableWAL: true
+        walMode: .durable,
+        storageFormat: .float32
     )
 
     /// In-memory only configuration (for testing).
@@ -49,7 +75,8 @@ public struct CacheConfiguration: Sendable {
         deduplicationThreshold: 0.98,
         autoEvict: true,
         ttlSeconds: 0,
-        enableWAL: false
+        walMode: .disabled,
+        storageFormat: .float32
     )
 
     public init(
@@ -59,7 +86,8 @@ public struct CacheConfiguration: Sendable {
         deduplicationThreshold: Float = 0.98,
         autoEvict: Bool = true,
         ttlSeconds: TimeInterval = 0,
-        enableWAL: Bool = true
+        walMode: CacheWALMode = .durable,
+        storageFormat: EmbeddingStorageFormat = .float32
     ) {
         self.maxEntries = maxEntries
         self.maxSizeBytes = maxSizeBytes
@@ -67,7 +95,30 @@ public struct CacheConfiguration: Sendable {
         self.deduplicationThreshold = deduplicationThreshold
         self.autoEvict = autoEvict
         self.ttlSeconds = ttlSeconds
-        self.enableWAL = enableWAL
+        self.walMode = walMode
+        self.storageFormat = storageFormat
+    }
+
+    @available(*, deprecated, message: "Use init with walMode instead")
+    public init(
+        maxEntries: Int = 100_000,
+        maxSizeBytes: Int64 = 500 * 1024 * 1024,
+        enableSemanticDedup: Bool = false,
+        deduplicationThreshold: Float = 0.98,
+        autoEvict: Bool = true,
+        ttlSeconds: TimeInterval = 0,
+        enableWAL: Bool
+    ) {
+        self.init(
+            maxEntries: maxEntries,
+            maxSizeBytes: maxSizeBytes,
+            enableSemanticDedup: enableSemanticDedup,
+            deduplicationThreshold: deduplicationThreshold,
+            autoEvict: autoEvict,
+            ttlSeconds: ttlSeconds,
+            walMode: enableWAL ? .durable : .disabled,
+            storageFormat: .float32
+        )
     }
 }
 
@@ -325,19 +376,68 @@ public enum TextHasher {
 
 /// Utilities for serializing embedding vectors to/from binary data.
 public enum VectorSerializer {
-    /// Serialize a Float array to binary data.
-    public static func serialize(_ vector: [Float]) -> Data {
-        vector.withUnsafeBytes { Data($0) }
+    /// Serialize a Float array to binary data using the specified format.
+    public static func serialize(_ vector: [Float], format: EmbeddingStorageFormat = .float32) -> Data {
+        switch format {
+        case .float32:
+            return vector.withUnsafeBytes { Data($0) }
+        case .int8:
+            let quantized = CPUQuantizer.quantizeToInt8(vector)
+            return serializeQuantized(quantized)
+        case .binary:
+            let quantized = CPUQuantizer.quantizeToBinary(vector)
+            return serializeQuantized(quantized)
+        }
     }
 
-    /// Deserialize binary data to a Float array.
-    public static func deserialize(_ data: Data, dimensions: Int) -> [Float]? {
-        guard data.count == dimensions * MemoryLayout<Float>.size else {
-            return nil
+    /// Deserialize binary data to a Float array using the specified format.
+    public static func deserialize(_ data: Data, dimensions: Int, format: EmbeddingStorageFormat = .float32) -> [Float]? {
+        switch format {
+        case .float32:
+            guard data.count == dimensions * MemoryLayout<Float>.size else {
+                return nil
+            }
+            return data.withUnsafeBytes { buffer in
+                Array(buffer.bindMemory(to: Float.self))
+            }
+        case .int8:
+            guard let quantized = deserializeQuantized(data, format: .int8, dimensions: dimensions) else { return nil }
+            return CPUQuantizer.dequantize(quantized)
+        case .binary:
+            guard let quantized = deserializeQuantized(data, format: .binary, dimensions: dimensions) else { return nil }
+            return CPUQuantizer.dequantize(quantized)
         }
+    }
 
-        return data.withUnsafeBytes { buffer in
-            Array(buffer.bindMemory(to: Float.self))
-        }
+    // MARK: - Private Helpers
+
+    private static func serializeQuantized(_ quantized: QuantizedVector) -> Data {
+        var data = Data()
+        var scale = quantized.params.scale
+        var offset = quantized.params.offset
+        var minValue = quantized.params.minValue
+        var maxValue = quantized.params.maxValue
+        
+        data.append(withUnsafeBytes(of: &scale) { Data($0) })
+        data.append(withUnsafeBytes(of: &offset) { Data($0) })
+        data.append(withUnsafeBytes(of: &minValue) { Data($0) })
+        data.append(withUnsafeBytes(of: &maxValue) { Data($0) })
+        data.append(quantized.data)
+        return data
+    }
+
+    private static func deserializeQuantized(_ data: Data, format: QuantizationFormat, dimensions: Int) -> QuantizedVector? {
+        let paramsSize = 4 * MemoryLayout<Float>.size
+        guard data.count >= paramsSize else { return nil }
+        
+        let scale = data[0..<4].withUnsafeBytes { $0.load(as: Float.self) }
+        let offset = data[4..<8].withUnsafeBytes { $0.load(as: Float.self) }
+        let minValue = data[8..<12].withUnsafeBytes { $0.load(as: Float.self) }
+        let maxValue = data[12..<16].withUnsafeBytes { $0.load(as: Float.self) }
+        
+        let params = QuantizationParams(scale: scale, offset: offset, minValue: minValue, maxValue: maxValue)
+        let vectorData = data.subdata(in: paramsSize..<data.count)
+        
+        return QuantizedVector(format: format, params: params, dimensions: dimensions, data: vectorData)
     }
 }

--- a/Sources/EmbedKit/Caching/PersistentCache.swift
+++ b/Sources/EmbedKit/Caching/PersistentCache.swift
@@ -298,9 +298,7 @@ public actor PersistentCache {
 
     private func setupDatabase() throws {
         // Configure connection
-        if config.enableWAL {
-            try connection.setWALMode(true)
-        }
+        try connection.setWALMode(config.walMode)
 
         // Create schema
         try connection.execute("""
@@ -396,7 +394,7 @@ public actor PersistentCache {
             return nil
         }
 
-        guard let vector = VectorSerializer.deserialize(vectorData, dimensions: Int(dimensions)) else {
+        guard let vector = VectorSerializer.deserialize(vectorData, dimensions: Int(dimensions), format: config.storageFormat) else {
             return nil
         }
 

--- a/Sources/EmbedKit/Caching/SQLiteConnection.swift
+++ b/Sources/EmbedKit/Caching/SQLiteConnection.swift
@@ -66,10 +66,22 @@ final class SQLiteConnection: @unchecked Sendable {
 
     // MARK: - Configuration
 
-    /// Enable or disable Write-Ahead Logging mode.
-    func setWALMode(_ enabled: Bool) throws {
-        let mode = enabled ? "WAL" : "DELETE"
-        try execute("PRAGMA journal_mode = \(mode)")
+    /// Set the Write-Ahead Logging mode.
+    func setWALMode(_ mode: CacheWALMode) throws {
+        switch mode {
+        case .disabled:
+            try execute("PRAGMA journal_mode = DELETE")
+            try execute("PRAGMA synchronous = OFF")
+        case .durable:
+            try execute("PRAGMA journal_mode = WAL")
+            try execute("PRAGMA synchronous = FULL")
+        case .balanced:
+            try execute("PRAGMA journal_mode = WAL")
+            try execute("PRAGMA synchronous = NORMAL")
+        case .performant:
+            try execute("PRAGMA journal_mode = WAL")
+            try execute("PRAGMA synchronous = OFF")
+        }
     }
 
     /// Set the cache size in pages (negative = KB).

--- a/Sources/EmbedKit/Optimization/Quantization.swift
+++ b/Sources/EmbedKit/Optimization/Quantization.swift
@@ -581,6 +581,78 @@ public enum CPUQuantizer {
         return result
     }
 
+    // MARK: - Int8 Implementation
+
+    public static func quantizeToInt8(_ vector: [Float]) -> QuantizedVector {
+        let count = vector.count
+        var minVal: Float = 0
+        var maxVal: Float = 0
+        vDSP_minv(vector, 1, &minVal, vDSP_Length(count))
+        vDSP_maxv(vector, 1, &maxVal, vDSP_Length(count))
+        
+        let maxAbs = max(abs(minVal), abs(maxVal))
+        let scale = maxAbs > 0 ? maxAbs / 127.0 : 1.0
+        var invScale = 1.0 / scale
+        
+        var scaledValues = [Float](repeating: 0, count: count)
+        vDSP_vsmul(vector, 1, &invScale, &scaledValues, 1, vDSP_Length(count))
+        
+        var int8Data = Data(count: count)
+        int8Data.withUnsafeMutableBytes { buffer in
+            let ptr = buffer.bindMemory(to: Int8.self)
+            for i in 0..<count {
+                let val = round(scaledValues[i])
+                ptr[i] = Int8(max(min(val, 127), -127))
+            }
+        }
+        
+        let params = QuantizationParams(
+            scale: scale,
+            offset: 0.0,
+            minValue: -maxAbs,
+            maxValue: maxAbs
+        )
+        
+        return QuantizedVector(
+            format: .int8,
+            params: params,
+            dimensions: count,
+            data: int8Data
+        )
+    }
+
+    // MARK: - Binary Implementation
+
+    public static func quantizeToBinary(_ vector: [Float]) -> QuantizedVector {
+        let count = vector.count
+        let numWords = (count + 31) / 32
+        var words = [UInt32](repeating: 0, count: numWords)
+        
+        for i in 0..<count {
+            if vector[i] > 0 {
+                let wordIndex = i / 32
+                let bitIndex = i % 32
+                words[wordIndex] |= (1 << bitIndex)
+            }
+        }
+        
+        let data = words.withUnsafeBytes { Data($0) }
+        
+        let params = QuantizationParams(
+            scale: 1.0,
+            offset: 0.0,
+            minValue: -1.0,
+            maxValue: 1.0
+        )
+        
+        return QuantizedVector(
+            format: .binary,
+            params: params,
+            dimensions: count,
+            data: data
+        )
+    }
+
     // MARK: - General Dequantize (for legacy support)
 
     public static func dequantize(_ quantized: QuantizedVector) -> [Float] {

--- a/Sources/EmbedKit/Storage/EmbeddingStore.swift
+++ b/Sources/EmbedKit/Storage/EmbeddingStore.swift
@@ -83,7 +83,11 @@ public actor EmbeddingStore: EmbeddingStorable {
 
         // Create GPU-accelerated index
         let vaConfig = config.toVectorAccelerate()
-        self.index = try await AcceleratedVectorIndex(configuration: vaConfig)
+        let manager = try? await AccelerationManager.create()
+        self.index = try await AcceleratedVectorIndex(
+            configuration: vaConfig,
+            decisionEngine: manager?.decisionEngine
+        )
     }
 
     /// Create an embedding store with a custom Metal4Context.
@@ -102,7 +106,12 @@ public actor EmbeddingStore: EmbeddingStorable {
         try config.validate()
 
         let vaConfig = config.toVectorAccelerate()
-        self.index = try await AcceleratedVectorIndex(configuration: vaConfig, context: context)
+        let manager = try? await AccelerationManager.create()
+        self.index = try await AcceleratedVectorIndex(
+            configuration: vaConfig,
+            context: context,
+            decisionEngine: manager?.decisionEngine
+        )
     }
 
     // MARK: - Store Operations
@@ -137,8 +146,9 @@ public actor EmbeddingStore: EmbeddingStorable {
         // Convert metadata to VectorAccelerate format
         let vaMetadata: VectorMetadata? = metadata
 
-        // Insert into GPU index
-        let handle = try await index.insert(embedding.vector, metadata: vaMetadata)
+        // Insert into GPU index (using VectorCore's DynamicVector as an IndexableVector)
+        let dynamicVector = DynamicVector(embedding.vector)
+        let handle = try await index.insert(dynamicVector, metadata: vaMetadata)
 
         // Store mappings
         handleToID[handle] = vectorId


### PR DESCRIPTION
### Context

This PR bridges two gaps identified during a downstream VSK upgrade audit and integrates the latest `VectorAccelerate` features:

### Gap 1: `CacheWALMode` enum on `CacheConfiguration`
- Added a `CacheWALMode` enum (`.disabled`, `.durable`, `.balanced`, `.performant`) to `CacheConfiguration`.
- `SQLiteConnection` now dynamically configures both `PRAGMA journal_mode` and `PRAGMA synchronous` based on the selected mode.
- Kept a deprecated `enableWAL` computed property for backwards compatibility.

### Gap 2: `EmbeddingStorageFormat` with int8 / binary quantization
- Added an `EmbeddingStorageFormat` enum (`.float32`, `.int8`, `.binary`) to `CacheConfiguration`.
- Implemented `quantizeToInt8` and `quantizeToBinary` symmetric/bit-packing algorithms in `CPUQuantizer`.
- Updated `VectorSerializer` to seamlessly quantize/dequantize embeddings and serialize their parameters directly into the SQLite binary blob.

### VectorAccelerate 0.4.3 Integration
- Upgraded the `VectorAccelerate` dependency to `0.4.3`.
- Exposed `decisionEngine` publicly on `AccelerationManager`.
- Wired `GPUDecisionEngine` into `AcceleratedVectorIndex` initialization to allow dynamic CPU fallback routing for small-N queries.
- Updated `EmbeddingStore.store()` to convert to a `DynamicVector` (an `IndexableVector` conformer) before passing to `index.insert()`, preserving vector metadata for future operations.