### PR TITLE
chore(deps): upgrade VectorAccelerate 0.4.3 → 0.4.4

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "60e19ae44ccab3d68c88736b9cdce7b7c62f3fe004a52d096371f9e38f1e85c5",
+  "originHash" : "a06f4d4ee124e3dadb19e7619d7155ebd9626d188f73ad4eb754505d2f0477a3",
   "pins" : [
     {
       "identity" : "metalcompilerplugin",
@@ -33,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/gifton/VectorAccelerate.git",
       "state" : {
-        "revision" : "ccb80e0abea884a6ae59ebb86fdc6132a010f778",
-        "version" : "0.4.3"
+        "revision" : "31495358626e5ba01cb9f605b779a3939889adb0",
+        "version" : "0.4.4"
       }
     },
     {
@@ -42,8 +42,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/gifton/VectorCore.git",
       "state" : {
-        "revision" : "bd6e3ffa61281d56960557f051a5fe746ea6a9e5",
-        "version" : "0.2.0"
+        "revision" : "c602b2e912b2adb053db36300343402862a3f968",
+        "version" : "0.2.1"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -45,8 +45,8 @@ let package = Package(
     ],
     dependencies: [
         // VSK dependencies - VectorAccelerate provides GPU-first vector indexing
-        .package(url: "https://github.com/gifton/VectorCore.git", from: "0.2.0"),
-        .package(url: "https://github.com/gifton/VectorAccelerate.git", from: "0.4.2"),
+        .package(url: "https://github.com/gifton/VectorCore.git", from: "0.2.1"),
+        .package(url: "https://github.com/gifton/VectorAccelerate.git", from: "0.4.4"),
 
         // System dependencies
         .package(url: "https://github.com/apple/swift-log.git", from: "1.5.0"),


### PR DESCRIPTION
## Summary

- Bumps `VectorAccelerate` from `0.4.3` → `0.4.4` and tightens the `VectorCore` floor from `0.2.0` → `0.2.1` (VA 0.4.4's new minimum).
- No source-level changes required. The only breaking change in VA 0.4.4 — removal of `walConfiguration` from `.ivfAuto(...)` — is **not** a call site in EmbedKit.
- Implied release: `v0.3.3` → `v0.3.4` (patch, dep-only). Tag after merge.

## What changed upstream (VA 0.4.4, commit `97cec69`)

- **Transparent internal refactor** — per-vector normalization hints moved from parallel arrays in `GPUVectorStorage` into a handle-keyed `VectorHintStore`; CPU top-K extracted into `CPUTopK.swift`.
- **New capability** — `NormalizationHint<V>` now conforms to `IndexableVector` (unlocked by VC 0.2.1). Sets up the cosine fast-path for when `.cosine` metric support lands in VA. Not adopted here — pure forward-prep.
- **Breaking** — `.ivfAuto(...)` no longer accepts `walConfiguration`. Callers wanting WAL on IVF use `.ivf(...)` (which still accepts it). **EmbedKit has zero `.ivfAuto(...)` call sites**, so no source edits were needed.

## Files

| File | Change |
|---|---|
| `Package.swift` | `VectorAccelerate`: `from: "0.4.2"` → `"0.4.4"`; `VectorCore`: `from: "0.2.0"` → `"0.2.1"` |
| `Package.resolved` | VA pinned at `0.4.4` (rev `31495358…`), VC at `0.2.1` |

## Follow-up (not in this PR)

`NormalizationHint` adoption is deferred until VA ships the `.cosine` fast-path — at that point wrap the insert at `Sources/EmbedKit/Storage/EmbeddingStore.swift:150-151` with `NormalizationHint.normalized(...)` driven by `embedding.metadata.normalized` (`Sources/EmbedKit/Core/Types.swift:152`). Tracked in the plan file only; no runtime benefit until the fast-path exists.

## Test plan

- [x] `swift build` — clean (only pre-existing `AccelerationManager.swift` async/throws warnings, unrelated to this PR)
- [x] `swift test` — 1697/1697 passed
- [x] `Package.resolved` pins verified: VA `31495358626e5ba01cb9f605b779a3939889adb0` (0.4.4) and VC 0.2.1
- [ ] Tag `v0.3.4` on `main` after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)